### PR TITLE
Updated calibration of membrane potential threshold

### DIFF
--- a/eglif_cond_alpha_multisyn.cpp
+++ b/eglif_cond_alpha_multisyn.cpp
@@ -521,7 +521,7 @@ void eglif_cond_alpha_multisyn::calibrate() {
 
   V_.receptors = 4;			// Number of receptor ports
 
-  V_.V_th = -50.0;
+  V_.V_th = P_.V_th;
 
   V_.I_gen = 0.0;
 


### PR DESCRIPTION
Except for the first simulation, at the beginning of each Nest simulation the threshold value of the membrane potential is set to a default value equal to -50 mV, until a spike is generated by that neuron.
Now, the threshold value is taken directly from the parameters even in the `calibrate()` function

Fixes #10 