### PR TITLE
Fixed stochasticity threshold parameters setting

### DIFF
--- a/eglif_cond_alpha_multisyn.cpp
+++ b/eglif_cond_alpha_multisyn.cpp
@@ -203,6 +203,8 @@ eglif_cond_alpha_multisyn::eglif_cond_alpha_multisyn(const eglif_cond_alpha_mult
   // copy parameter struct P_
   P_.C_m = __n.P_.C_m;
   P_.t_ref = __n.P_.t_ref;
+  P_.lambda_0 = __n.P_.lambda_0;
+  P_.tau_V = __n.P_.tau_V;
   P_.V_reset = __n.P_.V_reset;
   P_.tau_m = __n.P_.tau_m;
   P_.E_L = __n.P_.E_L;

--- a/eglif_cond_alpha_multisyn.h
+++ b/eglif_cond_alpha_multisyn.h
@@ -159,6 +159,7 @@ extern "C" inline int eglif_cond_alpha_multisyn_dynamics( double, const double y
 C_m [pF]  membrane parameters
  Membrane Capacitance
 t_ref [ms]  Refractory period
+lambda_0 and tau_V are the parameters for the stochasticity
 V_reset [mV]  Reset Potential
 tau_m [ms]  Membrane time constant
 E_L [mV]  Leak reversal Potential (aka resting potential)
@@ -1397,6 +1398,8 @@ inline void eglif_cond_alpha_multisyn::set_status(const DictionaryDatum &__d)
   // if we get here, temporaries contain consistent set of properties
   set_C_m(tmp_C_m);
   set_t_ref(tmp_t_ref);
+  set_lambda_0(tmp_lambda_0);
+  set_tau_V(tmp_tau_V);  
   set_V_reset(tmp_V_reset);
   set_tau_m(tmp_tau_m);
   set_E_L(tmp_E_L);


### PR DESCRIPTION
The stochasticity threshold parameters of the E-GLIF neuron, for the NEST 3 version of the module, did not get set to desired value but remained to the defaults value. Fixed here.